### PR TITLE
Flexible like dislike

### DIFF
--- a/application/main/routes.py
+++ b/application/main/routes.py
@@ -246,37 +246,52 @@ def add_or_remove_bookmark(bookmark, origin):
 @bp.route('/like/<recipe_url>', methods=['POST'])
 @login_required
 def like_recipe(recipe_url):
-    form = EmptyForm()
-    if form.validate_on_submit():
-        sort_by = request.form.get('sort_by')
-        sq.rate_recipe(current_user.userID, recipe_url, 5)
-        return redirect(url_for('main.profile', sort_by=sort_by))
-    else:
-        return redirect(url_for('main.profile', sort_by=sort_by))
+    sq.rate_recipe(current_user.userID, recipe_url, 5)
+    origin = request.args['origin']
+    sort_by = request.args['sort_by']
+    if origin == 'main.compare_recipes':
+        return redirect(url_for(origin, search_term=session['search_query'],
+                                sort_by=sort_by))
+    elif origin == 'main.search_results':
+        return redirect(url_for(origin, search_term=session['search_query'],
+                                sort_by=sort_by))
+    elif origin == 'main.profile':
+        return redirect(url_for(origin, sort_by=sort_by))
+    return redirect(url_for('main.home'))
 
 
 @bp.route('/dislike/<recipe_url>', methods=['POST'])
 @login_required
 def dislike_recipe(recipe_url):
-    form = EmptyForm()
-    if form.validate_on_submit():
-        sort_by = request.form.get('sort_by')
-        sq.rate_recipe(current_user.userID, recipe_url, 1)
-        return redirect(url_for('main.profile', sort_by=sort_by))
-    else:
-        return redirect(url_for('main.profile', sort_by=sort_by))
+    sq.rate_recipe(current_user.userID, recipe_url, 1)
+    origin = request.args['origin']
+    sort_by = request.args['sort_by']
+    if origin == 'main.compare_recipes':
+        return redirect(url_for(origin, search_term=session['search_query'],
+                                sort_by=sort_by))
+    elif origin == 'main.search_results':
+        return redirect(url_for(origin, search_term=session['search_query'],
+                                sort_by=sort_by))
+    elif origin == 'main.profile':
+        return redirect(url_for(origin, sort_by=sort_by))
+    return redirect(url_for('main.home'))
 
 
 @bp.route('/unlike/<recipe_url>', methods=['POST'])
 @login_required
 def unlike_recipe(recipe_url):
-    form = EmptyForm()
-    if form.validate_on_submit():
-        sort_by = request.form.get('sort_by')
-        sq.rate_recipe(current_user.userID, recipe_url, 3)
-        return redirect(url_for('main.profile', sort_by=sort_by))
-    else:
-        return redirect(url_for('main.profile', sort_by=sort_by))
+    sq.rate_recipe(current_user.userID, recipe_url, 3)
+    origin = request.args['origin']
+    sort_by = request.args['sort_by']
+    if origin == 'main.compare_recipes':
+        return redirect(url_for(origin, search_term=session['search_query'],
+                                sort_by=sort_by))
+    elif origin == 'main.search_results':
+        return redirect(url_for(origin, search_term=session['search_query'],
+                                sort_by=sort_by))
+    elif origin == 'main.profile':
+        return redirect(url_for(origin, sort_by=sort_by))
+    return redirect(url_for('main.home'))
 
 
 @bp.route('/about')

--- a/application/main/routes.py
+++ b/application/main/routes.py
@@ -53,7 +53,13 @@ def search_results(search_term):
         if current_user.is_authenticated:
             urls = list(results['url'].values)
 
-            # Bookmarked recipes
+            # Include user ratings in results
+            user_results = sq.query_user_ratings(current_user.userID, urls)
+            results = results.merge(user_results[['user_rating', 'recipesID']],
+                                    how='left', on='recipesID')
+            results['user_rating'].fillna(3, inplace=True)
+
+            # Include bookmarks in results
             df_bookmarks = sq.query_bookmarks(current_user.userID, urls)
             results = results.merge(df_bookmarks, how='left', on='recipesID')
             results['bookmarked'].fillna(False, inplace=True)

--- a/application/main/routes.py
+++ b/application/main/routes.py
@@ -101,11 +101,14 @@ def compare_recipes(search_term, Np=20):
     if current_user.is_authenticated:
         urls = list(results['url'].values)
 
-        # User ratings
+        # Include user ratings in results
         user_results = sq.query_user_ratings(current_user.userID, urls)
         user_ratings = hf.predict_user_ratings(user_results)
+        results = results.merge(user_results[['user_rating', 'recipesID']],
+                                how='left', on='recipesID')
+        results['user_rating'].fillna(3, inplace=True)
 
-        # Bookmarked recipes
+        # Include bookmarks in results
         df_bookmarks = sq.query_bookmarks(current_user.userID, urls)
         results = results.merge(df_bookmarks, how='left', on='recipesID')
         results['bookmarked'].fillna(False, inplace=True)

--- a/application/sql_queries.py
+++ b/application/sql_queries.py
@@ -524,10 +524,26 @@ class Sql_queries():
         # Find relevant likes row
         like = Like.query.filter_by(userID=userID,
                                     recipesID=recipeID).first()
-        # Add user rating and commit to DB
-        like.rating = rating
-        self.session.add(like)
-        self.session.commit()
+
+        # Like row found, modify
+        if like:
+            like.rating = rating
+            self.session.add(like)
+            self.session.commit()
+
+        # Like row not found, create new like entry (without bookmark)
+        else:
+            user = User.query.filter_by(userID=userID).first()
+            recipe = Recipe.query.filter_by(url=url).first()
+            if user and recipe:
+                like = Like(username=user.username,
+                            bookmarked=False,
+                            userID=userID,
+                            recipesID=recipe.recipesID,
+                            created=datetime.datetime.utcnow(),
+                            rating=rating)
+                self.session.add(like)
+                self.session.commit()
 
 
 # eof

--- a/application/templates/explore.html
+++ b/application/templates/explore.html
@@ -136,13 +136,13 @@
                 {% if df['user_rating'] == 5 %}
 
                     <!-- recipe was liked -->
-                    <form action="{{ url_for('main.dislike_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                    <form action="{{ url_for('main.dislike_recipe', recipe_url=df['url'], origin='main.search_results', sort_by=sort_by) }}" method="POST">
                         {{ like_form.csrf_token }}
                         <button type="submit" class="btn btn-dislike-unrated btn-sm" title="Dislike recipe">
                             <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                         </button>
                     </form>
-                    <form action="{{ url_for('main.unlike_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                    <form action="{{ url_for('main.unlike_recipe', recipe_url=df['url'], origin='main.search_results', sort_by=sort_by) }}" method="POST">
                         {{ like_form.csrf_token }}
                         <button type="submit" class="btn btn-like-rated btn-sm" title="Like recipe">
                             <i class="fa fa-thumbs-up" aria-hidden="true"></i>
@@ -151,13 +151,13 @@
                 {% elif df['user_rating'] == 1 %}
 
                     <!-- recipe was disliked -->
-                    <form action="{{ url_for('main.unlike_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                    <form action="{{ url_for('main.unlike_recipe', recipe_url=df['url'], origin='main.search_results', sort_by=sort_by) }}" method="POST">
                         {{ like_form.csrf_token }}
                         <button type="submit" class="btn btn-dislike-rated btn-sm" title="Dislike recipe">
                             <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                         </button>
                     </form>
-                    <form action="{{ url_for('main.like_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                    <form action="{{ url_for('main.like_recipe', recipe_url=df['url'], origin='main.search_results', sort_by=sort_by) }}" method="POST">
                         {{ like_form.csrf_token }}
                         <button type="submit" class="btn btn-like-unrated btn-sm" title="Like recipe">
                             <i class="fa fa-thumbs-up" aria-hidden="true"></i>
@@ -166,13 +166,13 @@
                 {% else %}
                     
                     <!-- recipe was neither liked nor disliked -->
-                    <form action="{{ url_for('main.dislike_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                    <form action="{{ url_for('main.dislike_recipe', recipe_url=df['url'], origin='main.search_results', sort_by=sort_by) }}" method="POST">
                         {{ like_form.csrf_token }}
                         <button type="submit" class="btn btn-dislike-unrated btn-sm" title="Dislike recipe">
                             <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                         </button>
                     </form>
-                    <form action="{{ url_for('main.like_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                    <form action="{{ url_for('main.like_recipe', recipe_url=df['url'], origin='main.search_results', sort_by=sort_by) }}" method="POST">
                         {{ like_form.csrf_token }}
                         <button type="submit" class="btn btn-like-unrated btn-sm" title="Like recipe">
                             <i class="fa fa-thumbs-up" aria-hidden="true"></i>

--- a/application/templates/profile.html
+++ b/application/templates/profile.html
@@ -239,13 +239,13 @@
                     {% if df['user_rating'] == 5 %}
 
                         <!-- recipe was liked -->
-                        <form action="{{ url_for('main.dislike_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                        <form action="{{ url_for('main.dislike_recipe', recipe_url=df['url'], origin='main.profile', sort_by=sort_by) }}" method="POST">
                             {{ like_form.csrf_token }}
                             <button type="submit" class="btn btn-dislike-unrated btn-sm" title="Dislike recipe">
                                 <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                             </button>
                         </form>
-                        <form action="{{ url_for('main.unlike_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                        <form action="{{ url_for('main.unlike_recipe', recipe_url=df['url'], origin='main.profile', sort_by=sort_by) }}" method="POST">
                             {{ like_form.csrf_token }}
                             <button type="submit" class="btn btn-like-rated btn-sm" title="Like recipe">
                                 <i class="fa fa-thumbs-up" aria-hidden="true"></i>
@@ -254,13 +254,13 @@
                     {% elif df['user_rating'] == 1 %}
 
                         <!-- recipe was disliked -->
-                        <form action="{{ url_for('main.unlike_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                        <form action="{{ url_for('main.unlike_recipe', recipe_url=df['url'], origin='main.profile', sort_by=sort_by) }}" method="POST">
                             {{ like_form.csrf_token }}
                             <button type="submit" class="btn btn-dislike-rated btn-sm" title="Dislike recipe">
                                 <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                             </button>
                         </form>
-                        <form action="{{ url_for('main.like_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                        <form action="{{ url_for('main.like_recipe', recipe_url=df['url'], origin='main.profile', sort_by=sort_by) }}" method="POST">
                             {{ like_form.csrf_token }}
                             <button type="submit" class="btn btn-like-unrated btn-sm" title="Like recipe">
                                 <i class="fa fa-thumbs-up" aria-hidden="true"></i>
@@ -269,13 +269,13 @@
                     {% else %}
                         
                         <!-- recipe was neither liked nor disliked -->
-                        <form action="{{ url_for('main.dislike_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                        <form action="{{ url_for('main.dislike_recipe', recipe_url=df['url'], origin='main.profile', sort_by=sort_by) }}" method="POST">
                             {{ like_form.csrf_token }}
                             <button type="submit" class="btn btn-dislike-unrated btn-sm" title="Dislike recipe">
                                 <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                             </button>
                         </form>
-                        <form action="{{ url_for('main.like_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                        <form action="{{ url_for('main.like_recipe', recipe_url=df['url'], origin='main.profile', sort_by=sort_by) }}" method="POST">
                             {{ like_form.csrf_token }}
                             <button type="submit" class="btn btn-like-unrated btn-sm" title="Like recipe">
                                 <i class="fa fa-thumbs-up" aria-hidden="true"></i>

--- a/application/templates/results.html
+++ b/application/templates/results.html
@@ -141,13 +141,13 @@
             {% if reference_recipe['user_rating'] == 5 %}
 
                 <!-- recipe was liked -->
-                <form action="{{ url_for('main.dislike_recipe', recipe_url=reference_recipe['url'], sort_by=sort_by) }}" method="POST">
+                <form action="{{ url_for('main.dislike_recipe', recipe_url=reference_recipe['url'], origin='main.compare_recipes', sort_by=sort_by) }}" method="POST">
                     {{ like_form.csrf_token }}
                     <button type="submit" class="btn btn-dislike-unrated btn-sm" title="Dislike recipe">
                         <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                     </button>
                 </form>
-                <form action="{{ url_for('main.unlike_recipe', recipe_url=reference_recipe['url'], sort_by=sort_by) }}" method="POST">
+                <form action="{{ url_for('main.unlike_recipe', recipe_url=reference_recipe['url'], origin='main.compare_recipes', sort_by=sort_by) }}" method="POST">
                     {{ like_form.csrf_token }}
                     <button type="submit" class="btn btn-like-rated btn-sm" title="Like recipe">
                         <i class="fa fa-thumbs-up" aria-hidden="true"></i>
@@ -156,13 +156,13 @@
             {% elif reference_recipe['user_rating'] == 1 %}
 
                 <!-- recipe was disliked -->
-                <form action="{{ url_for('main.unlike_recipe', recipe_url=reference_recipe['url'], sort_by=sort_by) }}" method="POST">
+                <form action="{{ url_for('main.unlike_recipe', recipe_url=reference_recipe['url'], origin='main.compare_recipes', sort_by=sort_by) }}" method="POST">
                     {{ like_form.csrf_token }}
                     <button type="submit" class="btn btn-dislike-rated btn-sm" title="Dislike recipe">
                         <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                     </button>
                 </form>
-                <form action="{{ url_for('main.like_recipe', recipe_url=reference_recipe['url'], sort_by=sort_by) }}" method="POST">
+                <form action="{{ url_for('main.like_recipe', recipe_url=reference_recipe['url'], origin='main.compare_recipes', sort_by=sort_by) }}" method="POST">
                     {{ like_form.csrf_token }}
                     <button type="submit" class="btn btn-like-unrated btn-sm" title="Like recipe">
                         <i class="fa fa-thumbs-up" aria-hidden="true"></i>
@@ -171,13 +171,13 @@
             {% else %}
                 
                 <!-- recipe was neither liked nor disliked -->
-                <form action="{{ url_for('main.dislike_recipe', recipe_url=reference_recipe['url'], sort_by=sort_by) }}" method="POST">
+                <form action="{{ url_for('main.dislike_recipe', recipe_url=reference_recipe['url'], origin='main.compare_recipes', sort_by=sort_by) }}" method="POST">
                     {{ like_form.csrf_token }}
                     <button type="submit" class="btn btn-dislike-unrated btn-sm" title="Dislike recipe">
                         <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                     </button>
                 </form>
-                <form action="{{ url_for('main.like_recipe', recipe_url=reference_recipe['url'], sort_by=sort_by) }}" method="POST">
+                <form action="{{ url_for('main.like_recipe', recipe_url=reference_recipe['url'], origin='main.compare_recipes', sort_by=sort_by) }}" method="POST">
                     {{ like_form.csrf_token }}
                     <button type="submit" class="btn btn-like-unrated btn-sm" title="Like recipe">
                         <i class="fa fa-thumbs-up" aria-hidden="true"></i>
@@ -408,13 +408,13 @@
                 {% if df['user_rating'] == 5 %}
 
                     <!-- recipe was liked -->
-                    <form action="{{ url_for('main.dislike_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                    <form action="{{ url_for('main.dislike_recipe', recipe_url=df['url'], origin='main.compare_recipes', sort_by=sort_by) }}" method="POST">
                         {{ like_form.csrf_token }}
                         <button type="submit" class="btn btn-dislike-unrated btn-sm" title="Dislike recipe">
                             <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                         </button>
                     </form>
-                    <form action="{{ url_for('main.unlike_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                    <form action="{{ url_for('main.unlike_recipe', recipe_url=df['url'], origin='main.compare_recipes', sort_by=sort_by) }}" method="POST">
                         {{ like_form.csrf_token }}
                         <button type="submit" class="btn btn-like-rated btn-sm" title="Like recipe">
                             <i class="fa fa-thumbs-up" aria-hidden="true"></i>
@@ -423,13 +423,13 @@
                 {% elif df['user_rating'] == 1 %}
 
                     <!-- recipe was disliked -->
-                    <form action="{{ url_for('main.unlike_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                    <form action="{{ url_for('main.unlike_recipe', recipe_url=df['url'], origin='main.compare_recipes', sort_by=sort_by) }}" method="POST">
                         {{ like_form.csrf_token }}
                         <button type="submit" class="btn btn-dislike-rated btn-sm" title="Dislike recipe">
                             <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                         </button>
                     </form>
-                    <form action="{{ url_for('main.like_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                    <form action="{{ url_for('main.like_recipe', recipe_url=df['url'], origin='main.compare_recipes', sort_by=sort_by) }}" method="POST">
                         {{ like_form.csrf_token }}
                         <button type="submit" class="btn btn-like-unrated btn-sm" title="Like recipe">
                             <i class="fa fa-thumbs-up" aria-hidden="true"></i>
@@ -438,13 +438,13 @@
                 {% else %}
                     
                     <!-- recipe was neither liked nor disliked -->
-                    <form action="{{ url_for('main.dislike_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                    <form action="{{ url_for('main.dislike_recipe', recipe_url=df['url'], origin='main.compare_recipes', sort_by=sort_by) }}" method="POST">
                         {{ like_form.csrf_token }}
                         <button type="submit" class="btn btn-dislike-unrated btn-sm" title="Dislike recipe">
                             <i class="fa fa-thumbs-down" aria-hidden="true"></i>
                         </button>
                     </form>
-                    <form action="{{ url_for('main.like_recipe', recipe_url=df['url'], sort_by=sort_by) }}" method="POST">
+                    <form action="{{ url_for('main.like_recipe', recipe_url=df['url'], origin='main.compare_recipes', sort_by=sort_by) }}" method="POST">
                         {{ like_form.csrf_token }}
                         <button type="submit" class="btn btn-like-unrated btn-sm" title="Like recipe">
                             <i class="fa fa-thumbs-up" aria-hidden="true"></i>


### PR DESCRIPTION
Likes and dislikes are now shown not only for profile, but also compare_recipes and search_results routes. In addition, it is possible to modify them from each route and get redirected to the route where the request was made. The only thing that does not yet work perfectly in that they might change after clicking a like or dislike button are the ordering of results and the page number from which the request was made.