### PR TITLE
Verify email

### DIFF
--- a/application/auth/email.py
+++ b/application/auth/email.py
@@ -12,5 +12,15 @@ def send_password_reset_email(user):
                html_body=render_template('email/reset_password.html',
                                          user=user, token=token))
 
+def send_verification_email(user):
+    token = user.get_verify_email_token()
+    send_email('[Sustainable-recipe-recommender] Verify email address',
+               sender=current_app.config['MAIL_USERNAME'],
+               recipients=[user.email],
+               text_body=render_template('email/verify_email.txt',
+                                         user=user, token=token),
+               html_body=render_template('email/verify_email.html',
+                                         user=user, token=token))
+
 
 # eof

--- a/application/auth/email.py
+++ b/application/auth/email.py
@@ -12,6 +12,7 @@ def send_password_reset_email(user):
                html_body=render_template('email/reset_password.html',
                                          user=user, token=token))
 
+
 def send_verification_email(user):
     token = user.get_verify_email_token()
     send_email('[Sustainable-recipe-recommender] Verify email address',

--- a/application/auth/forms.py
+++ b/application/auth/forms.py
@@ -96,6 +96,11 @@ class ResetPasswordForm(FlaskForm):
     submit = SubmitField('Request Password Reset')
 
 
+class VerifyEmailRequestForm(FlaskForm):
+    submit_verify_email = SubmitField('Send verification email',
+                                      validators=[])
+
+
 class NewsletterForm(FlaskForm):
     submit_newsletter = SubmitField('Change newsletter subscription',
                                     validators=[])

--- a/application/auth/forms.py
+++ b/application/auth/forms.py
@@ -25,18 +25,18 @@ def invalid_credentials(form, field):
 class RegistrationForm(FlaskForm):
     username = StringField('username', validators=[
                     InputRequired(message="Username required"),
-                    Length(min=4, max=25, message="Username must \
+                    Length(min=4, max=35, message="Username must \
                         be between 4 and 25 characters")
                     ])
     email = StringField('email', validators=[
                     InputRequired(message="Email required"),
                     Email(message="Please enter a valid email address"),
-                    Length(min=4, max=35, message="Please \
+                    Length(min=4, max=50, message="Please \
                         enter a valid email address")
                     ])
     password = PasswordField('password', validators=[
                     InputRequired(message="Password required"),
-                    Length(min=8, max=25, message="Password must be \
+                    Length(min=8, max=35, message="Password must be \
                         between 8 and 25 characters")
                     ])
     confirm_pswd = PasswordField('confirm_pswd', validators=[

--- a/application/auth/forms.py
+++ b/application/auth/forms.py
@@ -25,18 +25,18 @@ def invalid_credentials(form, field):
 class RegistrationForm(FlaskForm):
     username = StringField('username', validators=[
                     InputRequired(message="Username required"),
-                    Length(min=4, max=35, message="Username must \
+                    Length(min=4, max=25, message="Username must \
                         be between 4 and 25 characters")
                     ])
     email = StringField('email', validators=[
                     InputRequired(message="Email required"),
                     Email(message="Please enter a valid email address"),
-                    Length(min=4, max=50, message="Please \
+                    Length(min=4, max=35, message="Please \
                         enter a valid email address")
                     ])
     password = PasswordField('password', validators=[
                     InputRequired(message="Password required"),
-                    Length(min=8, max=35, message="Password must be \
+                    Length(min=8, max=25, message="Password must be \
                         between 8 and 25 characters")
                     ])
     confirm_pswd = PasswordField('confirm_pswd', validators=[

--- a/application/auth/routes.py
+++ b/application/auth/routes.py
@@ -55,6 +55,9 @@ def signup():
             db.session.add(consent)
             db.session.commit()
 
+            # email verification needed for newsletter
+            # TODO flash msg + send verification email
+
         flash('Account registered successfully. Please login.', 'success')
         return redirect(url_for('auth.signin'))
 

--- a/application/auth/routes.py
+++ b/application/auth/routes.py
@@ -133,10 +133,11 @@ def reset_password(token):
 def verify_email(token):
     if current_user.is_authenticated:
         user = User.verify_verify_email_token(token)
-        if current_user.email == user.email:
+        if user:
             user.confirmed = True
             db.session.commit()
             flash('Thank you. Your email has been verified.')
+            return redirect(url_for('main.profile'))
         else:
             flash('Oh oh! Email verification failed. \
                    Maybe the verificaiton link has expired. \

--- a/application/auth/routes.py
+++ b/application/auth/routes.py
@@ -58,7 +58,9 @@ def signup():
 
             # email verification needed for newsletter
             send_verification_email(user)
-            flash('A verification email has been sent to your address.')
+            flash('To receive newlsetter notifications you need to \
+                   verify your email address. A verification email \
+                   has been sent to your address.')
 
         flash('Account registered successfully. Please login.', 'success')
         return redirect(url_for('auth.signin'))

--- a/application/auth/routes.py
+++ b/application/auth/routes.py
@@ -131,17 +131,18 @@ def reset_password(token):
 
 @bp.route('/verify_email/<token>', methods=['GET', 'POST'])
 def verify_email(token):
-    user = User.verify_verify_email_token(token)
-    if current_user.email == user.email:
-        user.confirmed = True
-        db.session.commit()
-        flash('Thank you. Your email has been verified.')
-    else:
-        flash('Oh oh! Email verification failed.\
-                Maybe the verificaiton link has expired.\
-                You can try again using your profile page.')
     if current_user.is_authenticated:
-        return redirect(url_for('main.profile'))
+        user = User.verify_verify_email_token(token)
+        if current_user.email == user.email:
+            user.confirmed = True
+            db.session.commit()
+            flash('Thank you. Your email has been verified.')
+        else:
+            flash('Oh oh! Email verification failed. \
+                   Maybe the verificaiton link has expired. \
+                   You can try again using your profile page.')
+            return redirect(url_for('main.profile'))
+    flash('You need to be logged in in order to verify your email.')
     return redirect(url_for('main.home'))
 
 

--- a/application/auth/routes.py
+++ b/application/auth/routes.py
@@ -62,7 +62,9 @@ def signup():
                    verify your email address. A verification email \
                    has been sent to your address.')
 
-        flash('Account registered successfully. Please login.', 'success')
+        # Log user in automatically
+        login_user(user, remember=False)
+        flash('Account registered successfully.', 'success')
         return redirect(url_for('auth.signin'))
 
     return render_template('signup.html', reg_form=reg_form)

--- a/application/auth/routes.py
+++ b/application/auth/routes.py
@@ -10,7 +10,7 @@ from passlib.hash import pbkdf2_sha512
 
 # User made modules
 from application.auth.forms import RegistrationForm, LoginForm, \
-    ResetPasswordRequestForm, ResetPasswordForm
+    ResetPasswordRequestForm, ResetPasswordForm, VerifyEmailRequestForm
 
 # Database
 from application import db
@@ -127,6 +127,17 @@ def reset_password(token):
         flash('Your password has been reset.')
         return redirect(url_for('auth.signin'))
     return render_template('reset-password.html', form=form)
+
+
+@bp.route('/verify_email_request', methods=['GET', 'POST'])
+@login_required
+def verify_email_request():
+    form = VerifyEmailRequestForm()
+    if form.validate_on_submit():
+        send_password_reset_email(current_user)
+        flash('A verification link has been sent to your email.')
+        return redirect(url_for('main.home'))
+    return redirect(url_for('main.profile'))
 
 
 @bp.route('/verify_email/<token>', methods=['GET', 'POST'])

--- a/application/auth/routes.py
+++ b/application/auth/routes.py
@@ -19,7 +19,8 @@ from application.auth import bp
 import datetime
 
 # Email
-from application.auth.email import send_password_reset_email
+from application.auth.email import send_password_reset_email, \
+    send_verification_email
 
 
 @bp.route('/signup', methods=['GET', 'POST'])

--- a/application/auth/routes.py
+++ b/application/auth/routes.py
@@ -56,7 +56,8 @@ def signup():
             db.session.commit()
 
             # email verification needed for newsletter
-            # TODO flash msg + send verification email
+            send_verification_email(user)
+            flash('A verification email has been sent to your address.')
 
         flash('Account registered successfully. Please login.', 'success')
         return redirect(url_for('auth.signin'))
@@ -121,6 +122,22 @@ def reset_password(token):
         flash('Your password has been reset.')
         return redirect(url_for('auth.signin'))
     return render_template('reset-password.html', form=form)
+
+
+@bp.route('/verify_email/<token>', methods=['GET', 'POST'])
+def verify_email(token):
+    if current_user.is_authenticated:
+        user = User.verify_verify_email_token(token)
+        if current_user.email == user.email:
+            user.confirmed = True
+            db.session.commit()
+            flash('Thank you. Your email has been verified.')
+        else:
+            flash('Oh oh! Email verification failed.\
+                   Maybe the verificaiton link has expired.\
+                   You can try again using your profile page.')
+        return redirect(url_for('main.profile'))
+    return redirect(url_for('main.home'))
 
 
 # eof

--- a/application/auth/routes.py
+++ b/application/auth/routes.py
@@ -129,17 +129,6 @@ def reset_password(token):
     return render_template('reset-password.html', form=form)
 
 
-@bp.route('/verify_email_request', methods=['GET', 'POST'])
-@login_required
-def verify_email_request():
-    form = VerifyEmailRequestForm()
-    if form.validate_on_submit():
-        send_password_reset_email(current_user)
-        flash('A verification link has been sent to your email.')
-        return redirect(url_for('main.home'))
-    return redirect(url_for('main.profile'))
-
-
 @bp.route('/verify_email/<token>', methods=['GET', 'POST'])
 def verify_email(token):
     if current_user.is_authenticated:

--- a/application/auth/routes.py
+++ b/application/auth/routes.py
@@ -131,16 +131,16 @@ def reset_password(token):
 
 @bp.route('/verify_email/<token>', methods=['GET', 'POST'])
 def verify_email(token):
+    user = User.verify_verify_email_token(token)
+    if current_user.email == user.email:
+        user.confirmed = True
+        db.session.commit()
+        flash('Thank you. Your email has been verified.')
+    else:
+        flash('Oh oh! Email verification failed.\
+                Maybe the verificaiton link has expired.\
+                You can try again using your profile page.')
     if current_user.is_authenticated:
-        user = User.verify_verify_email_token(token)
-        if current_user.email == user.email:
-            user.confirmed = True
-            db.session.commit()
-            flash('Thank you. Your email has been verified.')
-        else:
-            flash('Oh oh! Email verification failed.\
-                   Maybe the verificaiton link has expired.\
-                   You can try again using your profile page.')
         return redirect(url_for('main.profile'))
     return redirect(url_for('main.home'))
 

--- a/application/main/routes.py
+++ b/application/main/routes.py
@@ -9,8 +9,10 @@ from flask_login import login_required, current_user
 import application.main.helper_functions as hf
 import application.main.altair_plots as ap
 from application.main.forms import SearchForm, EmptyForm
-from application.auth.forms import DeleteAccountForm, NewsletterForm
+from application.auth.forms import DeleteAccountForm, NewsletterForm,\
+    VerifyEmailRequestForm
 from application.sql_queries import Sql_queries
+from application.auth.email import send_verification_email
 
 # Database
 from application import db
@@ -237,6 +239,13 @@ def profile():
     search_form = SearchForm()
     delete_account_form = DeleteAccountForm()
     newsletter_form = NewsletterForm()
+    verify_email_form = VerifyEmailRequestForm()
+
+    # verifying email address
+    if verify_email_form.validate_on_submit():
+        send_verification_email(current_user)
+        flash('A verification link has been sent to your email address.')
+        return redirect(url_for('main.profile'))
 
     # subscribing / unsubscribing
     if newsletter_form.submit_newsletter.data and \
@@ -263,7 +272,8 @@ def profile():
     return render_template('profile.html',
                            search_form=search_form,
                            newsletter_form=newsletter_form,
-                           delete_account_form=delete_account_form)
+                           delete_account_form=delete_account_form,
+                           verify_email_form=verify_email_form)
 
 
 @bp.route('/about')

--- a/application/main/routes.py
+++ b/application/main/routes.py
@@ -242,7 +242,8 @@ def profile():
     verify_email_form = VerifyEmailRequestForm()
 
     # verifying email address
-    if verify_email_form.validate_on_submit():
+    if verify_email_form.submit_verify_email.data and \
+       verify_email_form.validate_on_submit():
         send_verification_email(current_user)
         flash('A verification link has been sent to your email address.')
         return redirect(url_for('main.profile'))

--- a/application/models.py
+++ b/application/models.py
@@ -19,7 +19,8 @@ class User(UserMixin, db.Model):
     def get_reset_password_token(self, expires_in=600):
         return jwt.encode(
             {'reset_password': self.get_id(), 'exp': time() + expires_in},
-            current_app.config['SECRET_KEY'], algorithm='HS256')
+            current_app.config['SECRET_KEY'], algorithm='HS256'
+        )
 
     @staticmethod
     def verify_reset_password_token(token):
@@ -30,6 +31,20 @@ class User(UserMixin, db.Model):
             return
         return User.query.get(id)
 
+    def get_verify_email_token(self, expires_in=600):
+        return jwt.encode(
+            {'verify_email': self.email, 'exp': time() + expires_in},
+            current_app.config['SECRET_KEY'], algorithm='HS256'
+        )
+
+    @staticmethod
+    def verify_verify_email_token(token):
+        try:
+            email = jwt.decode(token, current_app.config['SECRET_KEY'],
+                               algorithms=['HS256'])['verify_email']
+        except:
+            return
+        return User.query.filter_by(email=email).first()
 
 @login.user_loader
 def load_user(userID):

--- a/application/templates/email/verify_email.html
+++ b/application/templates/email/verify_email.html
@@ -1,0 +1,16 @@
+<p>Dear {{ user.username }},</p>
+<p>
+    To verify your email address, please click on the following link:
+    <a href="{{ url_for('auth.verify_email', token=token, _external=True) }}">
+        click here
+    </a>.
+</p>
+<p>Alternatively, you can paste the following link in your browser's address bar:</p>
+<p>{{ url_for('auth.verify_email', token=token, _external=True) }}</p>
+<p>The link will expire in 10 minutes.</p>
+<p>If you have received this message by mistake you can simply ignore it.</p>
+<p>Sincerely,</p>
+<p>The Sustainable-recipe-recommender Team</p>
+
+
+<!-- eof -->

--- a/application/templates/email/verify_email.html
+++ b/application/templates/email/verify_email.html
@@ -1,8 +1,8 @@
 <p>Dear {{ user.username }},</p>
 <p>
-    To verify your email address, please click on the following link:
+    To verify your email address:
     <a href="{{ url_for('auth.verify_email', token=token, _external=True) }}">
-        click here
+        Click here
     </a>.
 </p>
 <p>Alternatively, you can paste the following link in your browser's address bar:</p>

--- a/application/templates/email/verify_email.txt
+++ b/application/templates/email/verify_email.txt
@@ -1,0 +1,13 @@
+Dear {{ user.username }},
+
+To verify your email address, please click on the following link:
+
+{{ url_for('auth.verify_email', token=token, _external=True) }}
+
+The link will expire in 10 minutes.
+
+If you have received this message by mistake you can simply ignore it.
+
+Sincerely,
+
+The Sustainable-recipe-recommender Team

--- a/application/templates/profile.html
+++ b/application/templates/profile.html
@@ -47,15 +47,10 @@
 
                 <!-- Send verification email -->
                 <form action="{{ url_for('main.profile') }}", method="POST">
-                    <h5>Newsletter subscription</h5>
-                    {% if current_user.optin_news %}
-                        <p>Unsubscribe from email newsletter (you can re-subscribe anytime).</p>
-                        {{ newsletter_form.submit_newsletter(class_="btn btn-warning") }}
-                    {% else %}
-                        <p>Subscribe to email newsletter (you can unsubscribe anytime).</p>
-                        {{ newsletter_form.submit_newsletter(class_="btn btn-success") }}
-                    {% endif %}
-                    {{ newsletter_form.csrf_token }}
+                    <h5>Verify email address</h5>
+                    <p>Verify your email address (required for receiving newsletters).</p>
+                    {{ verify_email_form.submit_verify_email(class_="btn btn-success") }}
+                    {{ verify_email_form.csrf_token }}
                 </form> 
             {% endif %}
 

--- a/application/templates/profile.html
+++ b/application/templates/profile.html
@@ -26,18 +26,38 @@
     <br>
         <div>
             
-            <!-- Email newsletter opt-in / opt-out -->
-            <form action="{{ url_for('main.profile') }}", method="POST">
-                <h5>Newsletter subscription</h5>
-                {% if current_user.optin_news %}
-                    <p>Unsubscribe from email newsletter (you can re-subscribe anytime).</p>
-                    {{ newsletter_form.submit_newsletter(class_="btn btn-warning") }}
-                {% else %}
-                    <p>Subscribe to email newsletter (you can unsubscribe anytime).</p>
-                    {{ newsletter_form.submit_newsletter(class_="btn btn-success") }}
-                {% endif %}
-                {{ newsletter_form.csrf_token }}
-            </form> 
+            <!-- Email verified -->
+            {% if current_user.confirmed %}
+
+                <!-- Email newsletter opt-in / opt-out -->
+                <form action="{{ url_for('main.profile') }}", method="POST">
+                    <h5>Newsletter subscription</h5>
+                    {% if current_user.optin_news %}
+                        <p>Unsubscribe from email newsletter (you can re-subscribe anytime).</p>
+                        {{ newsletter_form.submit_newsletter(class_="btn btn-warning") }}
+                    {% else %}
+                        <p>Subscribe to email newsletter (you can unsubscribe anytime).</p>
+                        {{ newsletter_form.submit_newsletter(class_="btn btn-success") }}
+                    {% endif %}
+                    {{ newsletter_form.csrf_token }}
+                </form> 
+            
+            <!-- Email unverified -->
+            {% else %}
+
+                <!-- Send verification email -->
+                <form action="{{ url_for('main.profile') }}", method="POST">
+                    <h5>Newsletter subscription</h5>
+                    {% if current_user.optin_news %}
+                        <p>Unsubscribe from email newsletter (you can re-subscribe anytime).</p>
+                        {{ newsletter_form.submit_newsletter(class_="btn btn-warning") }}
+                    {% else %}
+                        <p>Subscribe to email newsletter (you can unsubscribe anytime).</p>
+                        {{ newsletter_form.submit_newsletter(class_="btn btn-success") }}
+                    {% endif %}
+                    {{ newsletter_form.csrf_token }}
+                </form> 
+            {% endif %}
 
             <!-- Delete account -->
             <br>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -211,6 +211,21 @@ class TestRoutesMain:
         assert r.status_code == 200
         assert b'Search for sustainable recipes' not in r.data
 
+        # Access profile route without verified email
+        u = User.query.filter_by(userID=user.userID).first()
+        u.confirmed = False
+        pg.session.commit()
+        r = test_client.post(url_for('main.profile'), follow_redirects=True)
+        assert b'Send verification email' in r.data
+        assert b'Change newsletter subscription' not in r.data
+
+        # Access profile route with verified email
+        u.confirmed = True
+        pg.session.commit()
+        r = test_client.post(url_for('main.profile'), follow_redirects=True)
+        assert b'Send verification email' not in r.data
+        assert b'Change newsletter subscription' in r.data
+
         # Newsletter subscription form
         old_status = User.query.filter_by(userID=user.userID).first() \
                          .optin_news

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -599,7 +599,7 @@ class TestRoutesAuth:
             'optin_terms': True,
             'optin_news': False
             }, follow_redirects=True)
-        assert b'Account registered successfully. Please login.' in r.data
+        assert b'Account registered successfully.' in r.data
 
         # Clean up: Delete dummy account
         u = User.query.filter_by(username=pg.dummy_name).first()
@@ -745,7 +745,7 @@ class TestRoutesAuth:
         assert route_meta_tag(r) == 'auth.signin'
         assert b'Your password has been reset.' in r.data
 
-    def test_verify_email(self, test_client, user):
+    def test_verify_email(self, test_client, user, pg):
         """
         When given a valid verify email token, updates table
         entry to user.confirmed = True


### PR DESCRIPTION
When users sign up a verification email is sent to their email address.

Additionally, users can send a verificaiton email from their profile route. 

Without a verified email address it is not possible to receive a newsletter. Hence, when an email is not verified the change newsletter subscription button does not appear in the profile route, instead a verify email button is presented. Once an email is verified this button disappears. 

Tests were included where necessary. 